### PR TITLE
Workaround for firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 		</center></div>
 	</div>
 
-	<div class=row>
+	<div class=row style="display: block"><!-- Firefox 34+ workaround -->
 		<div class="col-md-12">
 			<p><img src="assets/what-is-webpack.png" /></p>
 		</div>


### PR DESCRIPTION
Firefox 34+ ignores the "max-width: 100%" css property within flexbox. So users who use lastest firefox will get **huge** introduction image when they browse the webpack main page. [Please see this capture](http://i.imgur.com/j90rlfW.png)

Since the `<div>` tag that I changed doesn't need to be flexbox (it has only one child), I think this is the easiest way to workaround Firefox.

###### Reference

- http://stackoverflow.com/q/27472595