### PR TITLE
better cross browser zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 
-<div class=logo style="zoom: 3">
+<div class=logo style="-webkit-transform:scale(3);-ms-transform:scale(3);transform:scale(3);height:660px">
 <ul class=cube-inner>
 <li class=front></li>
 <li class=back></li>


### PR DESCRIPTION
`zoom` is a poorly supported attribute cross browser. Chrome fully supports it, Firefox doesnt at all, and Edge supports it on certain things. As a result, you get a super inconsistent and possibly broken experience. 

![image](https://cloud.githubusercontent.com/assets/465414/18229027/a6f4c60e-721c-11e6-878f-bf74801e065e.png)

This change gives a more consistent large icon look to the site. I would have added it to the css, but I wasn't sure where it was being loaded in from.
